### PR TITLE
implemented hompage button logic

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,7 +1,19 @@
 import NavigationItem from "@/components/navigation/NavigationItem";
 import { ArrowRight, CheckIcon } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 const Home = () => {
+
+  const navigate = useNavigate();
+
+  const handleSigninClick = () => {
+    navigate('/login');
+  };
+
+  const handleStartToday = () => {
+    navigate('/register');
+  };
+
   return (
     <>
       <div className="flex flex-col min-h-screen border-t-[1rem] md:border-t-[0.3rem] border-[#F74F39] bg-[#F4F3FA]">
@@ -28,7 +40,7 @@ const Home = () => {
           <div className="hidden font-semibold md:flex gap-9">
             <div className="hover:opacity-60 hover:cursor-pointer">Updates</div>
             <div className="hover:opacity-60 hover:cursor-pointer">Pricing</div>
-            <div className="text-[#F74F39] hover:cursor-pointer">
+            <div className="text-[#F74F39] hover:cursor-pointer" onClick={ handleSigninClick }>
               Sign in{" "}
               <span>
                 <ArrowRight
@@ -69,7 +81,7 @@ const Home = () => {
           </div>
 
           <div className="flex gap-3 mt-5 text-lg font-bold">
-            <button className="py-2 bg-[#F84F39] text-white rounded-full px-3 hover:scale-105 transition duration-200">
+            <button className="py-2 bg-[#F84F39] text-white rounded-full px-3 hover:scale-105 transition duration-200" onClick={ handleStartToday }>
               Start today — it's free{" "}
             </button>
             <button className="py-2 bg-[#6B66DA] text-white rounded-full px-3 hover:scale-105 transition duration-200">


### PR DESCRIPTION
This PR addresses the issue https://github.com/ProyectLink/super-list-frontend/issues/26 where sigin and start today were just rednered as dummy button and nothing was happening on clicking them.

Changes:
Added onClick function on both if these.
Clicking on signin button now directs to login page and clicking on start today button directs to register page.

Testing:

Tested these functionality on my machine locally.