### PR TITLE
Added feat: layout today task page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import Login from "@/pages/Login/Login";
 import Tasks from "@/components/tasks/Tasks";
+import Today from "@/pages/Today/Today";
 import Layout from "@/components/layouts/Layout";
 import SubTask from "@/pages/Tasks/SubTask";
 import Home from "./pages/Home/Home";
@@ -17,6 +18,7 @@ const App = () => {
           <Route path="" element={<Home />} />
           <Route path="login" element={<Login />} />
           <Route path="register" element={<Register />} />
+          <Route path="today" element={<Layout main={<Today />} />} />
           <Route path="all-tasks" element={<Layout main={<Tasks />} />}>
             <Route path=":taskId" element={<SubTask />} />
           </Route>

--- a/src/components/alert/Alert.tsx
+++ b/src/components/alert/Alert.tsx
@@ -5,14 +5,16 @@ import AlertMessage from "./AlertMessage";
 import AlertButtonsSection from "./AlertButtonsSection";
 import ButtonIcon from "../button/Button";
 
-const Alert = () => {
+interface Alerts extends React.HTMLAttributes<HTMLDivElement> {
+  message: string;
+}
+
+const Alert = ({ message }: Alerts) => {
   return (
     <>
       <AlertContainer>
         <AlertIcon />
-        <AlertMessage
-          message={" View, sort and access all of your tasks in one place"}
-        />
+        <AlertMessage message={message} />
         <AlertButtonsSection>
           <ButtonIcon icon={<ArrowUpRightIcon className="w-5 h-5" />} />
           <ButtonIcon icon={<XMarkIcon className="w-5 h-5" />} />

--- a/src/components/tasks/Tasks.tsx
+++ b/src/components/tasks/Tasks.tsx
@@ -12,7 +12,7 @@ export const Tasks = () => {
       <TasksContainer>
         <div className="w-11/12 mx-auto">
           <div className="mt-10 text-5xl font-bold opacity-85">Tasks</div>
-          <Alert />
+          <Alert message={" View, sort and access all of your tasks in one place"} />
         </div>
 
         <div className="mt-8">

--- a/src/pages/Today/Today.tsx
+++ b/src/pages/Today/Today.tsx
@@ -1,0 +1,19 @@
+import Alert from "../../components/alert/Alert";
+import TasksContainer from "../../components/tasks/TasksContainer";
+
+export const Today = () => {
+  return (
+    <>
+      <TasksContainer>
+        <div className="w-11/12 mx-auto">
+          <div className="mt-10 text-5xl font-bold opacity-85">Today</div>
+          <Alert message={"See what's due today and review any overdue tasks"}/>
+        </div>
+        {/* Add a new task component */}
+        <img src="/empty.png" className="mt-5 ms-5" />
+      </TasksContainer>
+    </>
+  );
+};
+
+export default Today;


### PR DESCRIPTION
This pull request implements the feature described in issue #23 , which introduces a `Today` Page.

### **Changes:**

- Added `Today` Page Route to App Component.
- Added `Today` Page component.
- Mutated the `Alert` component for reuse across both the `Tasks` Page and `Today` Page.

<img width="1512" alt="Screenshot 2024-10-02 at 11 21 10 AM" src="https://github.com/user-attachments/assets/6f2488c3-262d-4865-9dc8-1403bbebe326">
